### PR TITLE
Fix packagename nrsql -> nrredigo

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,4 +1,4 @@
-package nrsql
+package nrredigo
 
 // Config contains metadata to send to New Relic.
 type Config struct {


### PR DESCRIPTION
## WHY
`found packages nrsql (conn.go) and nrredigo (format.go) in ...`

## WHAT
- [x] `nrsql` -> `nrredigo`

@izumin5210